### PR TITLE
Home page: skeleton placeholders instead of holding all sections

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -203,19 +203,26 @@ async function loadLazy(doc) {
   loadHeader(doc.querySelector('header'));
   loadFooter(doc.querySelector('footer'));
 
-  // Load every below-the-fold section concurrently, but keep them hidden while
-  // loading and reveal them together, in document order. Concurrency keeps it
-  // fast (the per-section fragment fetches overlap instead of running one after
-  // another); the synchronized reveal means the content appears all at once
-  // with no per-section pop-in and, crucially, no reordering -- a faster lower
-  // section can never surface above a slower one that sits above it. Using
-  // visibility (not display) reserves layout space, so the reveal is shift-free.
+  // Reserve space for every below-the-fold section up front with a skeleton
+  // placeholder, then load them all concurrently and swap each skeleton for its
+  // real content as soon as it is ready ("show data as it loads"). Because each
+  // section already holds its slot in document order, a faster lower section
+  // simply fills its own reserved space -- it can never pop in above a slower
+  // section that sits above it (no reordering, minimal layout shift). The
+  // skeleton itself only appears if a section takes longer than ~200ms (see the
+  // .section-loading CSS), so fast sections show content directly with no flash.
   const pending = [...main.querySelectorAll('.section')]
     .filter((section) => section.dataset.sectionStatus !== 'loaded');
-  pending.forEach((section) => { section.style.visibility = 'hidden'; });
-  await Promise.all(pending.map((section) => loadSection(section)));
-  pending.forEach((section) => { section.style.visibility = ''; });
-  if (sampleRUM.enhance) sampleRUM.enhance();
+  pending.forEach((section) => {
+    section.style.display = '';
+    section.classList.add('section-loading');
+    section.setAttribute('aria-busy', 'true');
+  });
+  await Promise.all(pending.map((section, i) => loadSection(section).then(() => {
+    section.classList.remove('section-loading');
+    section.removeAttribute('aria-busy');
+    if (i === 0 && sampleRUM.enhance) sampleRUM.enhance();
+  })));
 
   // Highlight and optionally scroll to matches from ?highlight= query param
   if (main) highlightFromQuery(main);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -189,6 +189,50 @@ footer .footer[data-block-status="loaded"] {
   visibility: visible;
 }
 
+/* Section skeleton loading
+ * While a below-the-fold section loads, JS adds .section-loading to reserve its
+ * slot (so nothing pops in above it) and show a shimmer placeholder. The
+ * placeholder is delayed ~200ms so fast sections never flash a skeleton, and
+ * the shimmer only animates when the user has no reduced-motion preference. */
+main .section.section-loading {
+  position: relative;
+  min-height: 220px;
+}
+
+/* hide the section's raw, not-yet-decorated content behind the skeleton */
+main .section.section-loading > * {
+  visibility: hidden;
+}
+
+main .section.section-loading::after {
+  content: "";
+  position: absolute;
+  inset: 12px;
+  border-radius: 12px;
+  background-color: #eef1f6;
+  opacity: 0;
+  animation: section-skeleton-appear 0.2s ease-out 0.2s forwards;
+}
+
+@keyframes section-skeleton-appear {
+  to { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  main .section.section-loading::after {
+    background-image: linear-gradient(100deg, #eef1f6 40%, #f6f9fc 50%, #eef1f6 60%);
+    background-size: 200% 100%;
+    animation:
+      section-skeleton-appear 0.2s ease-out 0.2s forwards,
+      section-skeleton-shimmer 1.4s linear 0.2s infinite;
+  }
+}
+
+@keyframes section-skeleton-shimmer {
+  from { background-position: 150% 0; }
+  to { background-position: -150% 0; }
+}
+
 h1,
 h2,
 h3,


### PR DESCRIPTION
The merged loader hid every below-the-fold section until all of them finished, so the fast top content (hero-quote) waited on the slowest section lower down.

Reserve each pending section's slot up front with a skeleton placeholder, load all sections concurrently, and swap each skeleton for real content as soon as it is ready. Each section holds its place in document order from the start, so content fills its own reserved space -- no reordering, minimal layout shift, and data appears progressively as it loads instead of all-or-nothing. Per skeleton-screen best practice the shimmer is delayed ~200ms (fast sections never flash a skeleton), runs at 1.4s, animates only under prefers-reduced-motion: no-preference, and loading sections carry aria-busy.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--tech-council--aemsites.aem.live/
- After: https://<branch>--tech-council--aemsites.aem.live/
