### PR TITLE
Update doc-search no-match message for events/recordings scope

### DIFF
--- a/blocks/doc-search/doc-search.js
+++ b/blocks/doc-search/doc-search.js
@@ -766,7 +766,7 @@ export default async function decorate(block) {
   const noResults = createTag(
     'li',
     { class: 'doc-search-no-result', 'aria-hidden': true },
-    'We didn\'t find a good match. <a href="/docs/">Visit our documentation page</a> for more.',
+    'No matching events or recordings found. Try a different search.',
   );
   results.append(noResults);
   // add functionality to search bar


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--tech-council--aemsites.aem.live/
- After: https://<branch>--tech-council--aemsites.aem.live/
